### PR TITLE
Added multiple ways to authorize credentials

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,13 @@ name: run-tests
 
 on:
     push:
-        branches: [dev]
+        branches: [main]
     pull_request:
-        branches: [dev]
+        branches: [main]
+
+concurrency:
+    group: build-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
     test:

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -4,6 +4,25 @@ return [
     //the type of year to use for Quarter, fiscal or calendar
     'year_type'   => env('ANALYTICS_YEAR_TYPE', 'fiscal'),
     'property_id' => env('ANALYTICS_PROPERTY_ID'),
-    'credentials_path' => env('ANALYTICS_CREDENTIALS_PATH'),
-	'credentials_file' => env('ANALYTICS_CREDENTIALS_FILE'),
+
+	'credentials' => [
+		'use_env' => env('ANALYTICS_CREDENTIALS_USE_ENV', true),
+
+		'file' => env('ANALYTICS_CREDENTIALS_FILE'),
+
+		'json' => env('ANALYTICS_CREDENTIALS_JSON'),
+
+		'array' => env('ANALYTICS_CREDENTIALS_ARRAY', [
+			'type' => env('ANALYTICS_CREDENTIALS_TYPE'),
+			'project_id' => env('ANALYTICS_CREDENTIALS_PROJECT_ID'),
+			'private_key_id' => env('ANALYTICS_CREDENTIALS_PRIVATE_KEY_ID'),
+			'private_key' => env('ANALYTICS_CREDENTIALS_PRIVATE_KEY'),
+			'client_email' => env('ANALYTICS_CREDENTIALS_CLIENT_EMAIL'),
+			'client_id' => env('ANALYTICS_CREDENTIALS_CLIENT_ID'),
+			'auth_uri' => env('ANALYTICS_CREDENTIALS_AUTH_URI'),
+			'token_uri' => env('ANALYTICS_CREDENTIALS_TOKEN_URI'),
+			'auth_provider_x509_cert_url' => env('ANALYTICS_CREDENTIALS_AUTH_PROVIDER_X509_CERT_URL'),
+			'client_x509_cert_url' => env('ANALYTICS_CREDENTIALS_CLIENT_X509_CERT_URL'),
+		]),
+	]
 ];

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ Build Google Analytics queries in Laravel with ease.
 
 Via Composer
 
-``` bash
-$ composer require garrettmassey/analytics
+```SHELL
+composer require garrettmassey/analytics
 ```
 
 ## Setup
@@ -35,7 +35,7 @@ Make sure you have Google Analytics Data API enabled. NOTE: this is NOT the same
 
 //PIC
 
-Once enabled, select the Google Analytics Data API from the list of APIs, and click the Credentials tab. 
+Once enabled, select the Google Analytics Data API from the list of APIs, and click the Credentials tab.
 
 //PIC
 
@@ -51,7 +51,54 @@ Once the service account is created, add a new key to the service account. Selec
 
 Once the key is created, download the JSON file and save it somewhere safe. You will need this file to use this package. If you lose this file, you will have to create a new service account. Google does not let you re-issue keys.
 
-Move the `JSON` key file to your project's `root/analyticsAPI` directory. Name the file `credentials.json`. 
+You can use these credentials in several ways:
+
+### As ENV value (default)
+This is ideal setup if you're using only one service account for your application.
+
+Specify the path to the JSON file in your .env file:
+```dotenv
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+```
+
+### As a separate JSON file
+If you have multiple service accounts, you can instruct this package to use a specific one:
+
+```dotenv
+ANALYTICS_CREDENTIALS_USE_ENV=false
+ANALYTICS_CREDENTIALS_FILE=/path/to/credentials.json
+```
+
+### As a JSON string
+If you don't want to store the credentials in a file, you can specify the JSON string directly in your .env file:
+
+```dotenv
+ANALYTICS_CREDENTIALS_USE_ENV=false
+ANALYTICS_CREDENTIALS_JSON="{type: service_account, project_id: ...}"
+```
+
+### As separate values
+You can also specify the credentials as separate values in your .env file:
+
+```dotenv
+ANALYTICS_CREDENTIALS_USE_ENV=false
+ANALYTICS_CREDENTIALS_TYPE=service_account
+ANALYTICS_CREDENTIALS_PROJECT_ID=...
+ANALYTICS_CREDENTIALS_PRIVATE_KEY_ID=...
+ANALYTICS_CREDENTIALS_PRIVATE_KEY=...
+ANALYTICS_CREDENTIALS_CLIENT_EMAIL=...
+ANALYTICS_CREDENTIALS_CLIENT_ID=...
+ANALYTICS_CREDENTIALS_AUTH_URI=...
+ANALYTICS_CREDENTIALS_TOKEN_URI=...
+ANALYTICS_CREDENTIALS_AUTH_PROVIDER_X509_CERT_URL=...
+ANALYTICS_CREDENTIALS_CLIENT_X509_CERT_URL=...
+```
+
+> **Warning**
+> Package will always prioritize `GOOGLE_APPLICATION_CREDENTIALS` env value over other options. If you want to use a separate service account, make sure to set `ANALYTICS_CREDENTIALS_USE_ENV=false`.
+
+
+Move the `JSON` key file to your project's `root/analyticsAPI` directory. Name the file `credentials.json`.
 
 //PIC
 
@@ -61,7 +108,7 @@ Finally, open Google Analytics, and copy the property ID for the property you wa
 
 Set the property ID in your `.env` file, along with the year type (either fiscal or calendar).
 
-``` bash
+```dotenv
 ANALYTICS_YEAR_TYPE="fiscal|calendar"
 ANALYTICS_PROPERTY_ID="XXXXXXXXX"
 ```
@@ -76,11 +123,11 @@ Once installation is complete, you can run Google Analytics Data API queries in 
 
 All Google Analytics Data API queries require a date range to be run. Use the `Period` or `Quarter` classes to generate a period of time for the query.
 
-You can use two approaches to add query parameters to the request. 
+You can use two approaches to add query parameters to the request.
 
 ### 1. Callbacks
-``` php
-use GarrettMassey\Analytics\Facades\Analytics;
+```php
+use GarrettMassey\Analytics\Analytics;
 use GarrettMassey\Analytics\Period;
 
 $period = Period::create(
@@ -99,7 +146,7 @@ $report->setMetrics(function ($q) {
 This will return a collection of rows with additional fields for the metrics and dimensions.
 
 ### 2. Arrays
-``` php
+```php
 use GarrettMassey\Analytics\Facades\Analytics;
 use GarrettMassey\Analytics\Period;
 
@@ -121,7 +168,7 @@ This will return the same collection as the callback example. The two methods ex
 ### Provided Methods:
 
 #### getTopEvents()
-``` php
+```php
 $report = Analytics::getTopEvents();
 ```
 
@@ -140,8 +187,8 @@ To Be Completed
 
 TODO: write tests
 
-``` bash
-$ composer test
+```bash
+composer test
 ```
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -97,9 +97,6 @@ ANALYTICS_CREDENTIALS_CLIENT_X509_CERT_URL=...
 > **Warning**
 > Package will always prioritize `GOOGLE_APPLICATION_CREDENTIALS` env value over other options. If you want to use a separate service account, make sure to set `ANALYTICS_CREDENTIALS_USE_ENV=false`.
 
-
-Move the `JSON` key file to your project's `root/analyticsAPI` directory. Name the file `credentials.json`.
-
 //PIC
 
 Finally, open Google Analytics, and copy the property ID for the property you want to query. You will need this ID to use this package.

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use GarrettMassey\Analytics\Parameters\Dimensions;
 use GarrettMassey\Analytics\Parameters\Metrics;
 use Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
+use Google\Auth\CredentialsLoader;
 use Illuminate\Support\Collection;
 
 class Analytics {
@@ -30,7 +31,6 @@ class Analytics {
 
 	public function __construct()
 	{
-		putenv('GOOGLE_APPLICATION_CREDENTIALS=' . config('analytics.credentials_path'));
 		$this->client = resolve(BetaAnalyticsDataClient::class);
 		$this->propertyID = config('analytics.property_id');
 		$this->dimensions = collect([]);
@@ -40,7 +40,7 @@ class Analytics {
 		return $this;
 	}
 
-	public static function query()
+	public static function query(): Analytics
 	{
 		return new Analytics();
 	}

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace GarrettMassey\Analytics;
 
+use Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
+use Illuminate\Foundation\Application;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use GarrettMassey\Analytics\Commands\AnalyticsCommand;
@@ -19,5 +21,19 @@ class AnalyticsServiceProvider extends PackageServiceProvider
             ->name('analytics')
             ->hasConfigFile('analytics')
             ->hasCommand(AnalyticsCommand::class);
+
+		$this->app->bind(BetaAnalyticsDataClient::class, function () {
+			if (getenv('GOOGLE_APPLICATION_CREDENTIALS')) {
+				$credentials = null;
+			} elseif (config('analytics.credentials.file') !== null) {
+				$credentials = json_decode(file_get_contents(config('analytics.credentials.file')), true);
+			} elseif (config('analytics.credentials.json') !== null) {
+				$credentials = json_decode(config('analytics.credentials.json'), true);
+			} else {
+				$credentials = config('analytics.credentials.array');
+			}
+
+			return new BetaAnalyticsDataClient(['credentials' => $credentials]);
+		});
     }
 }

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -3,23 +3,56 @@
 namespace GarrettMassey\Analytics\Tests;
 
 use Carbon\CarbonImmutable;
-use GarrettMassey\Analytics\Facades\Analytics;
+use GarrettMassey\Analytics\Analytics;
 use Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
-use Illuminate\Support\Facades\App;
 use Mockery;
 use Mockery\MockInterface;
 
 class AnalyticsTest extends TestCase {
 
-	/** @test */
-	public function getClient_returns_GAClient()
+	public function test_client_init_with_default_credentials_env(): void
+	{
+		putenv('GOOGLE_APPLICATION_CREDENTIALS=' . storage_path('/framework/testing/disks/testing-storage/test-credentials.json'));
+		config()->set('analytics.credentials.file');
+
+		$this->assertInstanceOf(BetaAnalyticsDataClient::class, Analytics::query()->getClient());
+		putenv('GOOGLE_APPLICATION_CREDENTIALS=');
+	}
+
+	public function test_client_init_with_credentials_file(): void
 	{
 		$this->assertInstanceOf(BetaAnalyticsDataClient::class, Analytics::query()->getClient());
 	}
 
+	public function test_client_init_with_credentials_json_string(): void
+	{
+		config()->set('analytics.credentials.file');
+		config()->set('analytics.credentials.json', json_encode($this->credentials()));
 
+		$this->assertInstanceOf(BetaAnalyticsDataClient::class, Analytics::query()->getClient());
+	}
 
-	public function test_get_top_events()
+	public function test_client_init_with_credentials_array(): void
+	{
+		config()->set('analytics.credentials.file');
+		config()->set('analytics.credentials.array', $this->credentials());
+
+		$this->assertInstanceOf(BetaAnalyticsDataClient::class, Analytics::query()->getClient());
+	}
+
+	public function test_client_init_with_separate_credential_values(): void
+	{
+		config()->set('analytics.credentials.file');
+		$credentials = $this->credentials();
+
+		foreach ($credentials as $key => $value) {
+			config()->set('analytics.credentials.array.' . $key, $value);
+		}
+
+		$this->assertInstanceOf(BetaAnalyticsDataClient::class, Analytics::query()->getClient());
+	}
+
+	public function test_get_top_events(): void
 	{
 		CarbonImmutable::setTestNow(CarbonImmutable::create(2022, 11, 21));
 
@@ -46,8 +79,6 @@ class AnalyticsTest extends TestCase {
 		});
 
 		//TODO: assert response
-		Analytics::getTopEvents();
+		Analytics::query()->getTopEvents();
 	}
-
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,8 @@ use Google\Analytics\Data\V1beta\Metric;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\TestCase as Orchestra;
 
-class TestCase extends Orchestra {
+class TestCase extends Orchestra
+{
 	protected function getPackageProviders($app): array
 	{
 		return [
@@ -19,30 +20,33 @@ class TestCase extends Orchestra {
 
 	public function getEnvironmentSetUp($app)
 	{
-		Storage::fake('testing-storage');
+		$disk = Storage::fake('testing-storage');
 
-		Storage::disk('testing-storage')
-			->put('test-credentials.json', json_encode([
-			'type'                        => 'service_account',
-			'project_id'                  => 'bogus-project',
-			'private_key_id'              => 'bogus-id',
-			'private_key'                 => 'bogus-key',
-			'client_email'                => 'bogus-user@bogus-app.iam.gserviceaccount.com',
-			'client_id'                   => 'bogus-id',
-			'auth_uri'                    => 'https://accounts.google.com/o/oauth2/auth',
-			'token_uri'                   => 'https://accounts.google.com/o/oauth2/token',
-			'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
-			'client_x509_cert_url'        => 'https://www.googleapis.com/robot/v1/metadata/x509/bogus-ser%40bogus-app.iam.gserviceaccount.com',
-		]));
+		$disk->put('test-credentials.json', json_encode($this->credentials()));
+		$credentialsFile = storage_path('/framework/testing/disks/testing-storage/test-credentials.json');
 
-		$credentialsPath = storage_path('/framework/testing/disks/testing-storage/');
 		config()->set('analytics.property_id', 'test123');
-		config()->set('analytics.credentials_path', $credentialsPath . 'test-credentials.json');
+		config()->set('analytics.credentials.file', $credentialsFile);
+	}
+
+	protected function credentials(): array
+	{
+		return [
+			'type' => 'service_account',
+			'project_id' => 'bogus-project',
+			'private_key_id' => 'bogus-id',
+			'private_key' => 'bogus-key',
+			'client_email' => 'bogus-user@bogus-app.iam.gserviceaccount.com',
+			'client_id' => 'bogus-id',
+			'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+			'token_uri' => 'https://accounts.google.com/o/oauth2/token',
+			'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+			'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/bogus-ser%40bogus-app.iam.gserviceaccount.com',
+		];
 	}
 
 	/**
-	 * @param    array    $reportRequest
-	 *
+	 * @param array $reportRequest
 	 * @return array{property: string, dateRanges: DateRange[], dimensions: Dimension[], metrics: Metric[]}
 	 */
 	protected function parseReportRequest(array $reportRequest): array


### PR DESCRIPTION
Excerpt from readme:

Once the key is created, download the JSON file and save it somewhere safe. You will need this file to use this package. If you lose this file, you will have to create a new service account. Google does not let you re-issue keys.

You can use these credentials in several ways:

### As ENV value (default)
This is ideal setup if you're using only one service account for your application.

Specify the path to the JSON file in your .env file:
```dotenv
GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
```

### As a separate JSON file
If you have multiple service accounts, you can instruct this package to use a specific one:

```dotenv
ANALYTICS_CREDENTIALS_USE_ENV=false
ANALYTICS_CREDENTIALS_FILE=/path/to/credentials.json
```

### As a JSON string
If you don't want to store the credentials in a file, you can specify the JSON string directly in your .env file:

```dotenv
ANALYTICS_CREDENTIALS_USE_ENV=false
ANALYTICS_CREDENTIALS_JSON="{type: service_account, project_id: ...}"
```

### As separate values
You can also specify the credentials as separate values in your .env file:

```dotenv
ANALYTICS_CREDENTIALS_USE_ENV=false
ANALYTICS_CREDENTIALS_TYPE=service_account
ANALYTICS_CREDENTIALS_PROJECT_ID=...
ANALYTICS_CREDENTIALS_PRIVATE_KEY_ID=...
ANALYTICS_CREDENTIALS_PRIVATE_KEY=...
ANALYTICS_CREDENTIALS_CLIENT_EMAIL=...
ANALYTICS_CREDENTIALS_CLIENT_ID=...
ANALYTICS_CREDENTIALS_AUTH_URI=...
ANALYTICS_CREDENTIALS_TOKEN_URI=...
ANALYTICS_CREDENTIALS_AUTH_PROVIDER_X509_CERT_URL=...
ANALYTICS_CREDENTIALS_CLIENT_X509_CERT_URL=...
```

> **Warning**
> Package will always prioritize `GOOGLE_APPLICATION_CREDENTIALS` env value over other options. If you want to use a separate service account, make sure to set `ANALYTICS_CREDENTIALS_USE_ENV=false`.
