### PR TITLE
Implemented `ResponseData` object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
     ],
     "require": {
         "google/analytics-data": "^0.9.0",
-        "illuminate/support": "~9",
+        "illuminate/support": "^9.0",
         "nesbot/carbon": "^2.63",
+        "spatie/laravel-data": "^2.0",
         "spatie/laravel-package-tools": "^1.13"
     },
     "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 9
+    level: max
     paths:
         - src
         - config

--- a/src/Reports/Reports.php
+++ b/src/Reports/Reports.php
@@ -7,19 +7,15 @@ use GarrettMassey\Analytics\Analytics;
 use GarrettMassey\Analytics\Parameters\Dimensions;
 use GarrettMassey\Analytics\Parameters\Metrics;
 use GarrettMassey\Analytics\Period;
-use Google\Analytics\Data\V1beta\RunReportResponse;
+use GarrettMassey\Analytics\Response\ResponseData;
 use Google\ApiCore\ApiException;
-use Illuminate\Support\Collection;
 
 trait Reports
 {
     /**
-     * @param  Period|null  $period
-     * @return Collection<int, RunReportResponse>
-     *
      * @throws ApiException
      */
-    public static function getTopEvents(?Period $period = null): Collection
+    public static function getTopEvents(?Period $period = null): ResponseData
     {
         //create analytics instance
         $query = Analytics::query();

--- a/src/Response/DimensionHeader.php
+++ b/src/Response/DimensionHeader.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Data;
+
+class DimensionHeader extends Data
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Response/DimensionValue.php
+++ b/src/Response/DimensionValue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Data;
+
+class DimensionValue extends Data
+{
+    public function __construct(
+        public string $value,
+    ) {
+    }
+}

--- a/src/Response/Metadata.php
+++ b/src/Response/Metadata.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Data;
+
+class Metadata extends Data
+{
+    public function __construct(
+        public string $currencyCode,
+        public string $timeZone,
+    ) {
+    }
+}

--- a/src/Response/MetricHeader.php
+++ b/src/Response/MetricHeader.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Data;
+
+class MetricHeader extends Data
+{
+    public function __construct(
+        public string $name,
+        public string $type //Could be ENUM
+    ) {
+    }
+}

--- a/src/Response/MetricValue.php
+++ b/src/Response/MetricValue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Data;
+
+class MetricValue extends Data
+{
+    public function __construct(
+        public string $value,
+    ) {
+    }
+}

--- a/src/Response/PropertyQuota.php
+++ b/src/Response/PropertyQuota.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use GarrettMassey\Analytics\Response\Quotas\ConcurrentRequests;
+use GarrettMassey\Analytics\Response\Quotas\PotentiallyThresholdedRequestsPerHour;
+use GarrettMassey\Analytics\Response\Quotas\ServerErrorsPerProjectPerHour;
+use GarrettMassey\Analytics\Response\Quotas\TokensPerDay;
+use GarrettMassey\Analytics\Response\Quotas\TokensPerHour;
+use GarrettMassey\Analytics\Response\Quotas\TokensPerProjectPerHour;
+use Spatie\LaravelData\Data;
+
+class PropertyQuota extends Data
+{
+    public function __construct(
+        public TokensPerDay $tokensPerDay,
+        public TokensPerHour $tokensPerHour,
+        public ConcurrentRequests $concurrentRequests,
+        public ServerErrorsPerProjectPerHour $serverErrorsPerProjectPerHour,
+        public PotentiallyThresholdedRequestsPerHour $potentiallyThresholdedRequestsPerHour,
+        public TokensPerProjectPerHour $tokensPerProjectPerHour,
+    ) {
+    }
+}

--- a/src/Response/Quotas/ConcurrentRequests.php
+++ b/src/Response/Quotas/ConcurrentRequests.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response\Quotas;
+
+use Spatie\LaravelData\Data;
+
+class ConcurrentRequests extends Data
+{
+    public function __construct(
+        public int $remaining,
+    ) {
+    }
+}

--- a/src/Response/Quotas/PotentiallyThresholdedRequestsPerHour.php
+++ b/src/Response/Quotas/PotentiallyThresholdedRequestsPerHour.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response\Quotas;
+
+use Spatie\LaravelData\Data;
+
+class PotentiallyThresholdedRequestsPerHour extends Data
+{
+    public function __construct(
+        public int $remaining,
+    ) {
+    }
+}

--- a/src/Response/Quotas/ServerErrorsPerProjectPerHour.php
+++ b/src/Response/Quotas/ServerErrorsPerProjectPerHour.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response\Quotas;
+
+use Spatie\LaravelData\Data;
+
+class ServerErrorsPerProjectPerHour extends Data
+{
+    public function __construct(
+        public int $remaining,
+    ) {
+    }
+}

--- a/src/Response/Quotas/TokensPerDay.php
+++ b/src/Response/Quotas/TokensPerDay.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response\Quotas;
+
+use Spatie\LaravelData\Data;
+
+class TokensPerDay extends Data
+{
+    public function __construct(
+        public int $consumed,
+        public int $remaining,
+    ) {
+    }
+}

--- a/src/Response/Quotas/TokensPerHour.php
+++ b/src/Response/Quotas/TokensPerHour.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response\Quotas;
+
+use Spatie\LaravelData\Data;
+
+class TokensPerHour extends Data
+{
+    public function __construct(
+        public int $consumed,
+        public int $remaining,
+    ) {
+    }
+}

--- a/src/Response/Quotas/TokensPerProjectPerHour.php
+++ b/src/Response/Quotas/TokensPerProjectPerHour.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response\Quotas;
+
+use Spatie\LaravelData\Data;
+
+class TokensPerProjectPerHour extends Data
+{
+    public function __construct(
+        public int $consumed,
+        public int $remaining,
+    ) {
+    }
+}

--- a/src/Response/ResponseData.php
+++ b/src/Response/ResponseData.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class ResponseData extends Data
+{
+    /**
+     * @param  DataCollection<int, DimensionHeader>  $dimensionHeaders
+     * @param  DataCollection<int, MetricHeader>  $metricHeaders
+     * @param  DataCollection<int, Row>  $rows
+     * @param  DataCollection<int, Total>|null  $totals
+     * @param  int  $rowCount
+     * @param  Metadata  $metadata
+     * @param  PropertyQuota|null  $propertyQuota
+     * @param  string  $kind
+     */
+    public function __construct(
+        #[DataCollectionOf(DimensionHeader::class)]
+        public DataCollection $dimensionHeaders,
+        #[DataCollectionOf(MetricHeader::class)]
+        public DataCollection $metricHeaders,
+        #[DataCollectionOf(Row::class)]
+        public DataCollection $rows,
+        #[DataCollectionOf(Total::class)]
+        public ?DataCollection $totals,
+        public int $rowCount,
+        public Metadata $metadata,
+        public ?PropertyQuota $propertyQuota,
+        public string $kind,
+    ) {
+    }
+}

--- a/src/Response/Row.php
+++ b/src/Response/Row.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class Row extends Data
+{
+    /**
+     * @param  DataCollection<int, DimensionValue>  $dimensionValues
+     * @param  DataCollection<int, MetricValue>  $metricValues
+     */
+    public function __construct(
+        #[DataCollectionOf(DimensionValue::class)]
+        public DataCollection $dimensionValues,
+        #[DataCollectionOf(MetricValue::class)]
+        public DataCollection $metricValues,
+    ) {
+    }
+}

--- a/src/Response/Total.php
+++ b/src/Response/Total.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GarrettMassey\Analytics\Response;
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class Total extends Data
+{
+    /**
+     * @param  DataCollection<int, DimensionValue>  $dimensionValues
+     * @param  DataCollection<int, MetricValue>  $metricValues
+     */
+    public function __construct(
+        #[DataCollectionOf(DimensionValue::class)]
+        public DataCollection $dimensionValues,
+        #[DataCollectionOf(MetricValue::class)]
+        public DataCollection $metricValues,
+    ) {
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Exception;
 use GarrettMassey\Analytics\AnalyticsServiceProvider;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spatie\LaravelData\LaravelDataServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -13,6 +14,7 @@ class TestCase extends Orchestra
     {
         return [
             AnalyticsServiceProvider::class,
+            LaravelDataServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
Right now `ResponseData` matches `RunReportResponse` in terms of data structure, but it is fully typed because of generics. As you'll see in `AnalyticsTest` you can do this:
```PHP
$responseData->rows->first()?->metricValues->first()?->value;
``` 
and expect full IDE autocompletion:

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/17316322/203973319-8af27193-a23a-49a1-9f74-6cb39d5160ed.png">

---

I realize that at this point our `ReponseData` is just syntactic sugar. I've considered changing data format to something like this:
```
Illuminate\Support\Collection {#973 ▼
  #items: array:10 [▼
    0 => array:2 [▼
      "metrics" => array:1 [▼
        "eventCount" => "616494"
      ]
      "dimensions" => array:1 [▼
        "eventName" => "page_view"
      ]
    ]
    1 => array:2 [▼
      "metrics" => array:1 [▼
        "eventCount" => "220441"
      ]
      "dimensions" => array:1 [▼
        "eventName" => "session_start"
      ]
    ]
    2 => array:2 [▼
      "metrics" => array:1 [▼
        "eventCount" => "206643"
      ]
      "dimensions" => array:1 [▼
        "eventName" => "user_engagement"
      ]
    ]
    3 => array:2 [▼
      "metrics" => array:1 [▼
        "eventCount" => "161215"
      ]
      "dimensions" => array:1 [▼
        "eventName" => "scroll"
      ]
    ]
```

That might not be something end user wants though so I left the structure as it is. But since we now our response is custom data object, we can easily add methods to it that would return data in different formats. My suggestion is to keep it like this and if needed implement additional methods based on use case.

---

I've already created data objects for `totals` and `propertyQuota`, but I've left them commented out to not request them yet. I want to make a separate PR where we implement fluent way to use them.

To demonstrate how `ResponseData` object works, I created a new laravel project used it to display a table:

Route: 
```PHP
Route::get('/', function () {
    return view('data', [
        'data' => Analytics::getTopEvents(),
    ]);
});
```

View:
```BLADE
<table>
    <thead>
        <tr>
            @foreach($data->dimensionHeaders as $dimensionHeader)
                <th>{{ $dimensionHeader->name }}</th>
            @endforeach
            @foreach($data->metricHeaders as $metricHeader)
                <th>{{ $metricHeader->name }}</th>
            @endforeach
        </tr>
    </thead>
    <tbody>
        @foreach($data->rows as $row)
            <tr>
                @foreach($row->dimensionValues as $dimensionValue)
                    <td>{{ $dimensionValue->value }}</td>
                @endforeach
                @foreach($row->metricValues as $metricValue)
                    <td>{{ $metricValue->value }}</td>
                @endforeach
            </tr>
        @endforeach
    </tbody>
    <tfoot>
        @foreach($data->totals as $total)
            <tr>
                <td colspan="{{$total->dimensionValues->count()}}">TOTAL:</td>
                @foreach($total->metricValues as $metricValue)
                    <td>{{ $metricValue->value }}</td>
                @endforeach
            </tr>
        @endforeach
    </tfoot>
</table>
```

Result:
<img width="265" alt="image" src="https://user-images.githubusercontent.com/17316322/203975281-5440edd7-141d-4574-9f67-acd55a73051c.png">


Autocompletion works in blade too:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/17316322/203975680-652fefc9-431c-482d-934e-b609f79fcd3c.png">


---

Tests got a bit bulkier because of the mocking, but I'd like to address that in another PR. I think `AnalyticsTest` should only contain a few tests that build the request manually. and `ReportsTest` should use a `@dataProvider` to test all predefined reports.