### PR TITLE
Implemented `Period` class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,23 @@
         "Analytics"
     ],
     "require": {
+		"php": "^8.1",
         "google/analytics-data": "^0.9.0",
         "illuminate/support": "~9",
         "nesbot/carbon": "^2.63",
         "spatie/laravel-package-tools": "^1.13"
     },
     "require-dev": {
-        "brianium/paratest": "^6.6",
+        "brianium/paratest": "^6.6.5",
         "laravel/pint": "^1.2",
-        "nunomaduro/collision": "^6.2",
-        "nunomaduro/larastan": "^2.2",
-        "orchestra/testbench": "^7.13",
+        "nunomaduro/collision": "^6.3.1",
+        "nunomaduro/larastan": "^2.2.9",
+        "orchestra/testbench": "^7.14",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-mockery": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.2",
-        "phpunit/phpunit": "^9.5"
+        "phpstan/phpstan-phpunit": "^1.2.2",
+        "phpunit/phpunit": "^9.5.26"
     },
     "autoload": {
         "psr-4": {

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -156,7 +156,7 @@ class Analytics
 
     public function forPeriod(Period $period): static
     {
-        $this->dateRanges->push($period->getDateRanges());
+        $this->dateRanges->push($period->getDateRange());
 
         return $this;
     }

--- a/src/Period.php
+++ b/src/Period.php
@@ -7,6 +7,7 @@ use Carbon\CarbonInterface;
 use Closure;
 use Google\Analytics\Data\V1beta\DateRange;
 
+#[AllowDynamicProperties]
 class Period
 {
     public CarbonImmutable $startDate;

--- a/src/Period.php
+++ b/src/Period.php
@@ -26,6 +26,10 @@ class Period
         $this->endDate = $endDate;
     }
 
+    public function __set(string $name, mixed $value): void {
+        $this->{$name} = $value;
+    }
+
     public static function defaultPeriod(): self
     {
         if (self::$defaultPeriodClosure !== null) {

--- a/src/Period.php
+++ b/src/Period.php
@@ -14,7 +14,7 @@ class Period
     public CarbonImmutable $endDate;
 
     /**
-     * @var null|Closure(): Period
+     * @var (Closure(): Period)|null
      */
     private static ?Closure $defaultPeriodClosure = null;
 
@@ -38,6 +38,10 @@ class Period
         );
     }
 
+    /**
+     * @param (Closure(): Period)|null $periodClosure
+     * @return void
+     */
     public static function setDefaultPeriodClosure(?Closure $periodClosure = null): void
     {
         self::$defaultPeriodClosure = $periodClosure;

--- a/src/Period.php
+++ b/src/Period.php
@@ -7,7 +7,6 @@ use Carbon\CarbonInterface;
 use Closure;
 use Google\Analytics\Data\V1beta\DateRange;
 
-
 class Period
 {
     public CarbonImmutable $startDate;

--- a/src/Period.php
+++ b/src/Period.php
@@ -26,11 +26,6 @@ class Period
         $this->endDate = $endDate;
     }
 
-    public function __set(string $name, mixed $value): void
-    {
-        $this->properties[$name] = $value;
-    }
-
     public static function defaultPeriod(): self
     {
         if (self::$defaultPeriodClosure !== null) {

--- a/src/Period.php
+++ b/src/Period.php
@@ -26,10 +26,6 @@ class Period
         $this->endDate = $endDate;
     }
 
-    public function __set(string $name, mixed $value): void {
-        $this->{$name} = $value;
-    }
-
     public static function defaultPeriod(): self
     {
         if (self::$defaultPeriodClosure !== null) {

--- a/src/Period.php
+++ b/src/Period.php
@@ -17,9 +17,9 @@ class Period
     /**
      * @var (Closure(): Period)|null
      */
-    private static ?Closure $defaultPeriodClosure = null;
+    public static ?Closure $defaultPeriodClosure = null;
 
-    private static int $startOfWeek = CarbonInterface::MONDAY;
+    public static int $startOfWeek = CarbonInterface::MONDAY;
 
     public function __construct(CarbonImmutable $startDate, CarbonImmutable $endDate)
     {

--- a/src/Period.php
+++ b/src/Period.php
@@ -3,6 +3,8 @@
 namespace GarrettMassey\Analytics;
 
 use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Closure;
 use Google\Analytics\Data\V1beta\DateRange;
 
 class Period
@@ -11,11 +13,44 @@ class Period
 
     public CarbonImmutable $endDate;
 
+    /**
+     * @var null|Closure(): Period
+     */
+    private static ?Closure $defaultPeriodClosure = null;
+
+    private static int $startOfWeek = CarbonInterface::MONDAY;
+
     public function __construct(CarbonImmutable $startDate, CarbonImmutable $endDate)
     {
-        //construct period
         $this->startDate = $startDate;
         $this->endDate = $endDate;
+    }
+
+    public static function defaultPeriod(): self
+    {
+        if (self::$defaultPeriodClosure !== null) {
+            return (self::$defaultPeriodClosure)();
+        }
+
+        return self::create(
+            startDate: CarbonImmutable::today()->subDays(30),
+            endDate: CarbonImmutable::today(),
+        );
+    }
+
+    public static function setDefaultPeriodClosure(?Closure $periodClosure = null): void
+    {
+        self::$defaultPeriodClosure = $periodClosure;
+    }
+
+    public static function startOfWeek(): int
+    {
+        return self::$startOfWeek;
+    }
+
+    public static function setStartOfWeek(int $startOfWeek): void
+    {
+        self::$startOfWeek = $startOfWeek;
     }
 
     public static function create(CarbonImmutable $startDate, CarbonImmutable $endDate): self
@@ -23,67 +58,147 @@ class Period
         return new Period($startDate, $endDate);
     }
 
-    /**
-     * creates an instance of the period class for the last 7 days
-     */
-    public static function week(): self
+    public static function today(): self
     {
-        return new Period(CarbonImmutable::today()->subDays(7), CarbonImmutable::today());
+        return self::create(CarbonImmutable::today(), CarbonImmutable::today());
     }
 
-    /**
-     * creates an instance of the period class for the last 30 days
-     */
-    public static function month(): self
+    public static function yesterday(): self
     {
-        return new Period(CarbonImmutable::today()->subDays(30), CarbonImmutable::today());
+        return self::create(CarbonImmutable::yesterday(), CarbonImmutable::yesterday());
     }
 
-    /**
-     * creates an instance of the period class for the last 365 days
-     */
-    public static function year(): self
+    public static function lastDays(int $days): self
     {
-        return new Period(CarbonImmutable::today()->subDays(365), CarbonImmutable::today());
+        return new Period(CarbonImmutable::today()->subDays($days - 1), CarbonImmutable::today());
     }
 
-    /**
-     * creates an instance of the period class for the last n days
-     */
-    public static function days(int $days): self
+    public static function lastDaysExcludingToday(int $days): self
     {
-        return new Period(CarbonImmutable::today()->subDays($days), CarbonImmutable::today());
+        return new Period(CarbonImmutable::today()->subDays($days), CarbonImmutable::yesterday());
     }
 
-    /**
-     * creates an instance of the period class for the last n weeks
-     */
-    public static function weeks(int $weeks): self
+    public static function thisWeek(): self
     {
-        return new Period(CarbonImmutable::today()->subWeeks($weeks), CarbonImmutable::today());
+        return new Period(CarbonImmutable::today()->startOfWeek(self::$startOfWeek), CarbonImmutable::today());
     }
 
-    /**
-     * creates an instance of the period class for the last n months
-     */
-    public static function months(int $months): self
+    public static function thisWeekExcludingToday(): self
     {
-        return new Period(CarbonImmutable::today()->subMonths($months), CarbonImmutable::today());
+        return new Period(
+            startDate: $startOfWeek = CarbonImmutable::today()->startOfWeek(self::$startOfWeek),
+            endDate: $startOfWeek->isToday() ? CarbonImmutable::today() : CarbonImmutable::yesterday(),
+        );
     }
 
-    /**
-     * creates an instance of the period class for the last n years
-     */
-    public static function years(int $years): self
+    public static function lastWeek(): self
     {
-        return new Period(CarbonImmutable::today()->subYears($years), CarbonImmutable::today());
+        return new Period(
+            startDate: $startOfWeek = CarbonImmutable::today()->subWeek()->startOfWeek(self::$startOfWeek),
+            endDate: $startOfWeek->addDays(6),
+        );
     }
 
-    public function getDateRanges(): DateRange
+    public static function lastWeeks(int $weeks): self
+    {
+        return new Period(
+            startDate: CarbonImmutable::today()->subWeeks($weeks)->startOfWeek(self::$startOfWeek),
+            endDate: CarbonImmutable::today()->startOfWeek()->subDay(),
+        );
+    }
+
+    public static function thisMonth(): self
+    {
+        return new Period(CarbonImmutable::today()->startOfMonth(), CarbonImmutable::today());
+    }
+
+    public static function thisMonthExcludingToday(): self
+    {
+        return new Period(
+            startDate: $startOfMonth = CarbonImmutable::today()->startOfMonth(),
+            endDate: $startOfMonth->isToday() ? CarbonImmutable::today() : CarbonImmutable::yesterday(),
+        );
+    }
+
+    public static function lastMonth(): self
+    {
+        return new Period(
+            startDate: $startOfMonth = CarbonImmutable::today()->subMonthNoOverflow()->startOfMonth(),
+            endDate: $startOfMonth->endOfMonth(),
+        );
+    }
+
+    public static function lastMonths(int $months): self
+    {
+        return new Period(
+            startDate: CarbonImmutable::today()->subMonthsNoOverflow($months)->startOfMonth(),
+            endDate: CarbonImmutable::today()->startOfMonth()->subDay(),
+        );
+    }
+
+    public static function thisQuarter(): self
+    {
+        return new Period(CarbonImmutable::today()->startOfQuarter(), CarbonImmutable::today());
+    }
+
+    public static function thisQuarterExcludingToday(): self
+    {
+        return new Period(
+            startDate: $startOfQuarter = CarbonImmutable::today()->startOfQuarter(),
+            endDate: $startOfQuarter->isToday() ? CarbonImmutable::today() : CarbonImmutable::yesterday(),
+        );
+    }
+
+    public static function lastQuarter(): self
+    {
+        return new Period(
+            startDate: $startOfQuarter = CarbonImmutable::today()->subQuarterNoOverflow()->startOfQuarter(),
+            endDate: $startOfQuarter->endOfQuarter(),
+        );
+    }
+
+    public static function lastQuarters(int $quarters): self
+    {
+        return new Period(
+            startDate: CarbonImmutable::today()->subQuartersNoOverflow($quarters)->startOfQuarter(),
+            endDate: CarbonImmutable::today()->startOfQuarter()->subDay(),
+        );
+    }
+
+    public static function thisYear(): self
+    {
+        return new Period(CarbonImmutable::today()->startOfYear(), CarbonImmutable::today());
+    }
+
+    public static function thisYearExcludingToday(): self
+    {
+        return new Period(
+            startDate: $startOfYear = CarbonImmutable::today()->startOfYear(),
+            endDate: $startOfYear->isToday() ? CarbonImmutable::today() : CarbonImmutable::yesterday(),
+        );
+    }
+
+    public static function lastYear(): self
+    {
+        return new Period(
+            startDate: $startOfYear = CarbonImmutable::today()->subYearNoOverflow()->startOfYear(),
+            endDate: $startOfYear->endOfYear(),
+        );
+    }
+
+    public static function lastYears(int $years): self
+    {
+        return new Period(
+            startDate: CarbonImmutable::today()->subYears($years)->startOfYear(),
+            endDate: CarbonImmutable::today()->startOfYear()->subDay(),
+        );
+    }
+
+    public function getDateRange(): DateRange
     {
         return new DateRange([
-            'start_date' => $this->startDate->format('Y-m-d'),
-            'end_date' => $this->endDate->format('Y-m-d'),
+            'start_date' => $this->startDate->toDateString(),
+            'end_date' => $this->endDate->toDateString(),
         ]);
     }
 }

--- a/src/Period.php
+++ b/src/Period.php
@@ -7,7 +7,6 @@ use Carbon\CarbonInterface;
 use Closure;
 use Google\Analytics\Data\V1beta\DateRange;
 
-#[AllowDynamicProperties]
 class Period
 {
     public CarbonImmutable $startDate;

--- a/src/Period.php
+++ b/src/Period.php
@@ -7,6 +7,7 @@ use Carbon\CarbonInterface;
 use Closure;
 use Google\Analytics\Data\V1beta\DateRange;
 
+
 class Period
 {
     public CarbonImmutable $startDate;
@@ -16,14 +17,19 @@ class Period
     /**
      * @var (Closure(): Period)|null
      */
-    public static ?Closure $defaultPeriodClosure = null;
+    private static ?Closure $defaultPeriodClosure = null;
 
-    public static int $startOfWeek = CarbonInterface::MONDAY;
+    private static int $startOfWeek = CarbonInterface::MONDAY;
 
     public function __construct(CarbonImmutable $startDate, CarbonImmutable $endDate)
     {
         $this->startDate = $startDate;
         $this->endDate = $endDate;
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $this->properties[$name] = $value;
     }
 
     public static function defaultPeriod(): self

--- a/src/Reports/Reports.php
+++ b/src/Reports/Reports.php
@@ -2,7 +2,6 @@
 
 namespace GarrettMassey\Analytics\Reports;
 
-use Carbon\CarbonImmutable;
 use GarrettMassey\Analytics\Analytics;
 use GarrettMassey\Analytics\Parameters\Dimensions;
 use GarrettMassey\Analytics\Parameters\Metrics;
@@ -21,30 +20,10 @@ trait Reports
      */
     public static function getTopEvents(?Period $period = null): Collection
     {
-        //create analytics instance
-        $query = Analytics::query();
-        //if a period is provided, use that
-        if ($period) {
-            $query->setMetrics(function (Metrics $metric) {
-                return $metric->eventCount();
-            })->setDimensions(function (Dimensions $dimension) {
-                return $dimension->eventName();
-            })->forPeriod(
-                $period
-            );
-        } else {
-            $query->setMetrics(function (Metrics $metric) {
-                return $metric->eventCount();
-            })->setDimensions(function (Dimensions $dimension) {
-                return $dimension->eventName();
-            })->forPeriod(
-                Period::create(
-                    CarbonImmutable::now()->subDays(30),
-                    CarbonImmutable::now()
-                )
-            );
-        }
-
-        return $query->run();
+        return Analytics::query()
+            ->setMetrics(fn (Metrics $metric) => $metric->eventCount())
+            ->setDimensions(fn (Dimensions $dimension) => $dimension->eventName())
+            ->forPeriod($period ?? Period::defaultPeriod())
+            ->run();
     }
 }

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace GarrettMassey\Analytics\Tests;
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use GarrettMassey\Analytics\Period;
+use Google\Analytics\Data\V1beta\DateRange;
+
+class PeriodTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $startDate = CarbonImmutable::parse('2022-10-01');
+        $endDate = CarbonImmutable::parse('2022-10-31');
+
+        $period = new Period($startDate, $endDate);
+
+        $this->assertEquals($startDate->toDateString(), $period->startDate->toDateString());
+        $this->assertEquals($endDate->toDateString(), $period->endDate->toDateString());
+    }
+
+    public function test_default_period(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-31'));
+
+        $period = Period::defaultPeriod();
+
+        $this->assertEquals('2022-10-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-31', $period->endDate->toDateString());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_set_default_period(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-31'));
+
+        Period::setDefaultPeriodClosure(fn () => Period::create(
+            startDate: CarbonImmutable::today()->subDays(20),
+            endDate: CarbonImmutable::today(),
+        ));
+
+        $this->assertEquals('2022-10-11', Period::defaultPeriod()->startDate->toDateString());
+        $this->assertEquals('2022-10-31', Period::defaultPeriod()->endDate->toDateString());
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-01'));
+
+        $this->assertEquals('2022-10-12', Period::defaultPeriod()->startDate->toDateString());
+        $this->assertEquals('2022-11-01', Period::defaultPeriod()->endDate->toDateString());
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-31'));
+
+        Period::setDefaultPeriodClosure();
+
+        $this->assertEquals('2022-10-01', Period::defaultPeriod()->startDate->toDateString());
+        $this->assertEquals('2022-10-31', Period::defaultPeriod()->endDate->toDateString());
+    }
+
+    public function test_start_of_week(): void
+    {
+        $this->assertEquals(CarbonInterface::MONDAY, Period::startOfWeek());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_set_start_of_week(): void
+    {
+        Period::setStartOfWeek(CarbonInterface::SUNDAY);
+
+        $this->assertEquals(CarbonInterface::SUNDAY, Period::startOfWeek());
+
+        Period::setStartOfWeek(CarbonInterface::MONDAY);
+    }
+
+    public function test_create(): void
+    {
+        $startDate = CarbonImmutable::parse('2022-10-01');
+        $endDate = CarbonImmutable::parse('2022-10-31');
+
+        $period = Period::create($startDate, $endDate);
+
+        $this->assertEquals($startDate->toDateString(), $period->startDate->toDateString());
+        $this->assertEquals($endDate->toDateString(), $period->endDate->toDateString());
+    }
+
+    public function test_today(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-10'));
+
+        $period = Period::today();
+
+        $this->assertEquals('2022-10-10', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-10', $period->endDate->toDateString());
+    }
+
+    public function test_yesterday(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-10'));
+
+        $period = Period::yesterday();
+
+        $this->assertEquals('2022-10-09', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-09', $period->endDate->toDateString());
+    }
+
+    public function test_last_days(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-10'));
+
+        $period = Period::lastDays(7);
+
+        $this->assertEquals('2022-10-04', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-10', $period->endDate->toDateString());
+    }
+
+    public function test_last_days_excluding_today(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-10'));
+
+        $period = Period::lastDaysExcludingToday(7);
+
+        $this->assertEquals('2022-10-03', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-09', $period->endDate->toDateString());
+    }
+
+    public function test_this_week(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-10'));
+
+        $period = Period::thisWeek();
+
+        $this->assertEquals('2022-11-07', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-10', $period->endDate->toDateString());
+
+        Period::setStartOfWeek(CarbonInterface::SUNDAY);
+
+        $period = Period::thisWeek();
+
+        $this->assertEquals('2022-11-06', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-10', $period->endDate->toDateString());
+
+        Period::setStartOfWeek(CarbonInterface::MONDAY);
+    }
+
+    public function test_this_week_excluding_today(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-10'));
+
+        $period = Period::thisWeekExcludingToday();
+
+        $this->assertEquals('2022-11-07', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-09', $period->endDate->toDateString());
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-07'));
+
+        $period = Period::thisWeekExcludingToday();
+
+        $this->assertEquals('2022-11-07', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-07', $period->endDate->toDateString());
+    }
+
+    public function test_last_week(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-10'));
+
+        $period = Period::lastWeek();
+
+        $this->assertEquals('2022-10-31', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-06', $period->endDate->toDateString());
+    }
+
+    public function test_last_weeks(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-10'));
+
+        $period = Period::lastWeeks(4);
+
+        $this->assertEquals('2022-10-10', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-06', $period->endDate->toDateString());
+    }
+
+    public function test_this_month(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-10'));
+
+        $period = Period::thisMonth();
+
+        $this->assertEquals('2022-11-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-10', $period->endDate->toDateString());
+    }
+
+    public function test_this_month_excluding_today(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-10'));
+
+        $period = Period::thisMonthExcludingToday();
+
+        $this->assertEquals('2022-11-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-09', $period->endDate->toDateString());
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-01'));
+
+        $period = Period::thisMonthExcludingToday();
+
+        $this->assertEquals('2022-11-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-01', $period->endDate->toDateString());
+    }
+
+    public function test_last_month(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-03-31'));
+
+        $period = Period::lastMonth();
+
+        $this->assertEquals('2022-02-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-02-28', $period->endDate->toDateString());
+    }
+
+    public function test_last_months(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-03-31'));
+
+        $period = Period::lastMonths(3);
+
+        $this->assertEquals('2021-12-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-02-28', $period->endDate->toDateString());
+    }
+
+    public function test_this_quarter(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-24'));
+
+        $period = Period::thisQuarter();
+
+        $this->assertEquals('2022-10-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-24', $period->endDate->toDateString());
+    }
+
+    public function test_this_quarter_excluding_today(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-11-24'));
+
+        $period = Period::thisQuarterExcludingToday();
+
+        $this->assertEquals('2022-10-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-11-23', $period->endDate->toDateString());
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-01'));
+
+        $period = Period::thisQuarterExcludingToday();
+
+        $this->assertEquals('2022-10-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-01', $period->endDate->toDateString());
+    }
+
+    public function test_last_quarter(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-09-30'));
+
+        $period = Period::lastQuarter();
+
+        $this->assertEquals('2022-04-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-06-30', $period->endDate->toDateString());
+    }
+
+    public function test_last_quarters(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2021-12-31'));
+
+        $period = Period::lastQuarters(2);
+
+        $this->assertEquals('2021-04-01', $period->startDate->toDateString());
+        $this->assertEquals('2021-09-30', $period->endDate->toDateString());
+    }
+
+    public function test_this_year(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-10'));
+
+        $period = Period::thisYear();
+
+        $this->assertEquals('2022-01-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-10', $period->endDate->toDateString());
+    }
+
+    public function test_this_year_excluding_today(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-10-10'));
+
+        $period = Period::thisYearExcludingToday();
+
+        $this->assertEquals('2022-01-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-10-09', $period->endDate->toDateString());
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2022-01-01'));
+
+        $period = Period::thisYearExcludingToday();
+
+        $this->assertEquals('2022-01-01', $period->startDate->toDateString());
+        $this->assertEquals('2022-01-01', $period->endDate->toDateString());
+    }
+
+    public function test_last_year(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2020-02-29'));
+
+        $period = Period::lastYear();
+
+        $this->assertEquals('2019-01-01', $period->startDate->toDateString());
+        $this->assertEquals('2019-12-31', $period->endDate->toDateString());
+    }
+
+    public function test_last_years(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2020-02-29'));
+
+        $period = Period::lastYears(2);
+
+        $this->assertEquals('2018-01-01', $period->startDate->toDateString());
+        $this->assertEquals('2019-12-31', $period->endDate->toDateString());
+    }
+
+    public function test_get_date_ranges(): void
+    {
+        $startDate = CarbonImmutable::parse('2022-10-01');
+        $endDate = CarbonImmutable::parse('2022-10-31');
+
+        $period = new Period($startDate, $endDate);
+
+        $dateRange = $period->getDateRange();
+
+        $this->assertInstanceOf(DateRange::class, $dateRange);
+
+        $this->assertEquals($startDate->toDateString(), $dateRange->getStartDate());
+        $this->assertEquals($endDate->toDateString(), $dateRange->getEndDate());
+    }
+}


### PR DESCRIPTION
Implemented and fully tested `Period` class. It also includes quarters. I don't have any experience working with fiscal years so I skipped them for now. I tried looking for existing solutions that would be fluent as `Carbon`, but no such luck. I see you had some logic in `Quarter` class but I didn't dare to touch it. Maybe that could be a separate package? 😄 

---

I did add some customization to `Period` class:

## Start of week

```PHP
Period::setStartOfWeek(CarbonInterface::SUNDAY);
```

Allows setting different start of week. It uses a static parameter so it's enough to call this once at the start of the application and it will persist throughout. I did consider making it a config parameter, but there's a potential use case where you might want to make multiple requests with different starts of week and switching like this seems easier then setting new config value.

## Default period

```PHP
Period::setDefaultPeriodClosure(fn () => Period::create(
    startDate: CarbonImmutable::today()->subDays(20),
    endDate: CarbonImmutable::today(),
));
```

Allows user to set a different default period when using our predefined reports. For example, this is how our `getTopEvents()` report looks like:

```PHP
/**
 * @param  Period|null  $period
 * @return Collection<int, RunReportResponse>
 *
 * @throws ApiException
 */
public static function getTopEvents(?Period $period = null): Collection
{
    return Analytics::query()
        ->setMetrics(fn (Metrics $metric) => $metric->eventCount())
        ->setDimensions(fn (Dimensions $dimension) => $dimension->eventName())
        ->forPeriod($period ?? Period::defaultPeriod())
        ->run();
}
```

I preserved your initial default period of 30 days, but user might want to have 7 days by default without having to specify the period every time.

Before:
```PHP
$period = Period::lastDays(7);

Analytics::getTopEvents($period);
Analytics::getTopBrowsers($period);
Analytics::getTopCountries($period);
```

After:
```PHP
Period::setDefaultPeriodClosure(fn () => Period::lastDays(7));

Analytics::getTopEvents();
Analytics::getTopBrowsers();
Analytics::getTopCountries();
```

Again, this is done using a static parameter. You might notice that user has to pass in a closure. Initially I implemented it by passing in just a `Period` object, but then realized in tests that the period would get evaluated once and would always return the same date range even if I change today's date using `CarbonImmutable::setTestNow()`. Granted, in real life this might not matter much because PHP application is set up and destroyed with every request, but it would affect applications using [Octane](https://laravel.com/docs/9.x/octane) (see ["Managing memory leaks"](https://laravel.com/docs/9.x/octane#managing-memory-leaks)).

Anyway, I've type hinted this closure so anyone using phpstan would get warned about if they return something else rather then a `Period` object. But even if they do, I think it's their own fault 😄.

---

Also, I accounted for date overflowing. Example: imagine today is `2022-03-31` and you do a report for last month. You would expect the range to be `2022-02-01 - 2022-02-28`, but if you do `CarbonImmutable::today()->subMonth()->startOfMonth()` you get `2022-03-01` as start date, because `CarbonImmutable::today()->subMonth()` yields `2022-02-31` which is not a real date so it overflows to `2022-03-03`. I used `subMonthNoOverflow()` to account for this.

