### PR TITLE
Implemented order by

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,9 +405,9 @@ use Gtmassey\LaravelAnalytics\Analytics;
 use Gtmassey\Period\Period;
 
 $report = Analytics::query()
-	->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
-	->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser())
-	->forPeriod(Period::defaultPeriod())
+    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
+    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser())
+    ->forPeriod(Period::defaultPeriod())
     ->setOrderBys(fn(OrderBy $orderBy) => $orderBy
     	// Order by sessions in descending order
         ->metricDesc(
@@ -449,7 +449,7 @@ $report = Analytics::query()
             dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
         )
     )
-	->run();
+    ->run();
 ```
 
 ### <a name="defaultreports">Default Reports:</a>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Methods currently return an instance of `Gtmassey\LaravelAnalytics\ResponseData`
 * [Usage](#usage)
     * [Query Builder](#querybuilder)
     * [Filtering](#filtering)
+    * [Ordering](#ordering)
     * [Default Reports](#defaultreports)
 * [Extensibility](#extensibility)
     * [Custom Metrics And Dimensions](#custommetrics)
@@ -381,6 +382,74 @@ $report = Analytics::query()
         )
     )
     ->run();
+```
+
+### <a name="ordering">Ordering:</a>
+
+You can order the results by a metric or dimension by using the `setOrderBys()` method. This method accepts a callback that receives an `OrderBy` instance. You can then use the `OrderBy` instance to order the results using these methods:
+
+* `metricDesc()` - Order by a metric in descending order.
+* `metricAsc()` - Order by a metric in ascending order.
+* `alphanumericDimensionDesc()` - Order by a dimension in descending order (case-sensitive).
+* `alphanumericDimensionAsc()` - Order by a dimension in ascending order (case-sensitive).
+* `caseInsensitiveAlphanumericDimensionDesc()` - Order by a dimension in descending order (case-insensitive).
+* `caseInsensitiveAlphanumericDimensionAsc()` - Order by a dimension in ascending order (case-insensitive).
+* `numericDimensionDesc()` - Order by a dimension in descending order (numeric).
+* `numericDimensionAsc()` - Order by a dimension in ascending order (numeric).
+
+##### Example:
+```php
+use Gtmassey\LaravelAnalytics\Request\Dimensions;
+use Gtmassey\LaravelAnalytics\Request\Metrics;
+use Gtmassey\LaravelAnalytics\Analytics;
+use Gtmassey\Period\Period;
+
+$report = Analytics::query()
+	->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
+	->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser())
+	->forPeriod(Period::defaultPeriod())
+    ->setOrderBys(fn(OrderBy $orderBy) => $orderBy
+    	// Order by sessions in descending order
+        ->metricDesc(
+            metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
+        )
+
+        // Order by sessions in ascending order
+        ->metricAsc(
+            metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
+        )
+
+        // Order by browser in descending order (case-sensitive)
+        ->alphanumericDimensionDesc(
+            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
+        )
+
+        // Order by browser in ascending order (case-sensitive)
+        ->alphanumericDimensionAsc(
+            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
+        )
+
+        // Order by browser in descending order (case-insensitive)
+        ->caseInsensitiveAlphanumericDimensionDesc(
+            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
+        )
+
+        // Order by browser in ascending order (case-insensitive)
+        ->caseInsensitiveAlphanumericDimensionAsc(
+            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
+        )
+
+        // Order by browser in descending order (numeric)
+        ->numericDimensionDesc(
+            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
+        )
+
+        // Order by browser in ascending order (numeric)
+        ->numericDimensionAsc(
+            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
+        )
+    )
+	->run();
 ```
 
 ### <a name="defaultreports">Default Reports:</a>

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -11,6 +11,7 @@ use Gtmassey\LaravelAnalytics\Reports\Reports;
 use Gtmassey\LaravelAnalytics\Request\Dimensions;
 use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
 use Gtmassey\LaravelAnalytics\Request\Metrics;
+use Gtmassey\LaravelAnalytics\Request\OrderBy;
 use Gtmassey\LaravelAnalytics\Request\RequestData;
 use Gtmassey\LaravelAnalytics\Response\ResponseData;
 use Gtmassey\Period\Period;
@@ -105,6 +106,15 @@ class Analytics
             'end_date' => $period->endDate->toDateString(),
         ]);
         $this->requestData->dateRanges->push($dateRange);
+
+        return $this;
+    }
+
+    public function setOrderBys(Closure $callback): static
+    {
+        /** @var OrderBy $orderBy */
+        $orderBy = $callback(resolve(OrderBy::class));
+        $this->requestData->orderBys->push(...$orderBy->getOrderBys());
 
         return $this;
     }

--- a/src/Exceptions/InvalidOrderByException.php
+++ b/src/Exceptions/InvalidOrderByException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Exceptions;
+
+use Exception;
+
+class InvalidOrderByException extends Exception
+{
+    const NO_DIMENSION_ORDER_BY = 'No dimension to order by.';
+
+    const NO_METRIC_ORDER_BY = 'No metric to order by.';
+
+    public static function noDimensionOrderBy(): self
+    {
+        return new self(message: self::NO_DIMENSION_ORDER_BY);
+    }
+
+    public static function noMetricOrderBy(): self
+    {
+        return new self(message: self::NO_METRIC_ORDER_BY);
+    }
+}

--- a/src/Request/OrderBy.php
+++ b/src/Request/OrderBy.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request;
+
+use Closure;
+use Google\Analytics\Data\V1beta\OrderBy as BaseOrderBy;
+use Google\Analytics\Data\V1beta\OrderBy\DimensionOrderBy;
+use Google\Analytics\Data\V1beta\OrderBy\DimensionOrderBy\OrderType;
+use Google\Analytics\Data\V1beta\OrderBy\MetricOrderBy;
+use Gtmassey\LaravelAnalytics\Exceptions\InvalidOrderByException;
+use Illuminate\Support\Collection;
+
+class OrderBy
+{
+    public function __construct(
+        /** @var Collection<int, BaseOrderBy> */
+        private readonly Collection $orderBys = new Collection(),
+    ) {
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    private function metric(Closure $metricsCallback, bool $desc = false): static
+    {
+        /** @var Metrics $metrics */
+        $metrics = $metricsCallback(resolve(Metrics::class));
+
+        $firstMetric = $metrics->first();
+
+        if ($firstMetric === null) {
+            throw InvalidOrderByException::noMetricOrderBy();
+        }
+
+        $this->orderBys->add(new BaseOrderBy([
+            'metric' => new MetricOrderBy([
+                'metric_name' => $firstMetric->getName(),
+            ]),
+            'desc' => $desc,
+        ]));
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function metricDesc(Closure $metricsCallback): static
+    {
+        return $this->metric($metricsCallback, true);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function metricAsc(Closure $metricsCallback): static
+    {
+        return $this->metric($metricsCallback);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    private function dimension(Closure $dimensionsCallback, int $orderType, bool $desc = false): static
+    {
+        /** @var Dimensions $dimensions */
+        $dimensions = $dimensionsCallback(resolve(Dimensions::class));
+
+        $firstDimension = $dimensions->first();
+
+        if ($firstDimension === null) {
+            throw InvalidOrderByException::noDimensionOrderBy();
+        }
+
+        $this->orderBys->add(new BaseOrderBy([
+            'dimension' => new DimensionOrderBy([
+                'dimension_name' => $firstDimension->getName(),
+                'order_type' => $orderType,
+            ]),
+            'desc' => $desc,
+        ]));
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function alphanumericDimensionDesc(Closure $dimensionsCallback): static
+    {
+        return $this->dimension($dimensionsCallback, OrderType::ALPHANUMERIC, true);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function alphanumericDimensionAsc(Closure $dimensionsCallback): static
+    {
+        return $this->dimension($dimensionsCallback, OrderType::ALPHANUMERIC);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function caseInsensitiveAlphanumericDimensionDesc(Closure $dimensionsCallback): static
+    {
+        return $this->dimension($dimensionsCallback, OrderType::CASE_INSENSITIVE_ALPHANUMERIC, true);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function caseInsensitiveAlphanumericDimensionAsc(Closure $dimensionsCallback): static
+    {
+        return $this->dimension($dimensionsCallback, OrderType::CASE_INSENSITIVE_ALPHANUMERIC);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function numericDimensionDesc(Closure $dimensionsCallback): static
+    {
+        return $this->dimension($dimensionsCallback, OrderType::NUMERIC, true);
+    }
+
+    /**
+     * @throws InvalidOrderByException
+     */
+    public function numericDimensionAsc(Closure $dimensionsCallback): static
+    {
+        return $this->dimension($dimensionsCallback, OrderType::NUMERIC);
+    }
+
+    /**
+     * @return Collection<int, BaseOrderBy>
+     */
+    public function getOrderBys(): Collection
+    {
+        return $this->orderBys;
+    }
+}

--- a/src/Request/RequestData.php
+++ b/src/Request/RequestData.php
@@ -7,6 +7,7 @@ use Google\Analytics\Data\V1beta\Dimension;
 use Google\Analytics\Data\V1beta\FilterExpression as BaseFilterExpression;
 use Google\Analytics\Data\V1beta\Metric;
 use Google\Analytics\Data\V1beta\MetricAggregation;
+use Google\Analytics\Data\V1beta\OrderBy;
 use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Data;
@@ -31,6 +32,8 @@ class RequestData extends Data
         public ?FilterExpression $dimensionFilter = null,
 
         public ?FilterExpression $metricFilter = null,
+        /** @var Collection<int, OrderBy> */
+        public Collection $orderBys = new Collection(),
 
         public bool $returnPropertyQuota = true,
 
@@ -52,6 +55,7 @@ class RequestData extends Data
             'metrics' => $this->metrics->unique()->all(),
             'dimensionFilter' => $this->dimensionFilter?->toRequest(),
             'metricFilter' => $this->metricFilter?->toRequest(),
+            'orderBys' => $this->orderBys->all(),
             'returnPropertyQuota' => $this->returnPropertyQuota,
             'metricAggregations' => $this->useTotals ? [MetricAggregation::TOTAL] : [],
             'limit' => $this->limit,

--- a/tests/OrderBysTest.php
+++ b/tests/OrderBysTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Tests;
+
+use Google\Analytics\Data\V1beta\OrderBy as BaseOrderBy;
+use Gtmassey\LaravelAnalytics\Analytics;
+use Gtmassey\LaravelAnalytics\Exceptions\InvalidOrderByException;
+use Gtmassey\LaravelAnalytics\Request\Dimensions;
+use Gtmassey\LaravelAnalytics\Request\Metrics;
+use Gtmassey\LaravelAnalytics\Request\OrderBy;
+use Gtmassey\LaravelAnalytics\Request\RequestData;
+use ReflectionProperty;
+
+class OrderBysTest extends TestCase
+{
+    public function test_invalid_metric_order_by(): void
+    {
+        $this->expectException(InvalidOrderByException::class);
+        $this->expectExceptionMessage(InvalidOrderByException::NO_METRIC_ORDER_BY);
+
+        Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->metricDesc(fn (Metrics $metrics) => $metrics)
+            );
+    }
+
+    public function test_order_by_metric_asc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->metricAsc(fn (Metrics $metrics) => $metrics->sessions())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'metric' => [
+                'metricName' => 'sessions',
+            ],
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_order_by_metric_desc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->metricDesc(fn (Metrics $metrics) => $metrics->sessions())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'metric' => [
+                'metricName' => 'sessions',
+            ],
+            'desc' => true,
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_invalid_dimension_order_by(): void
+    {
+        $this->expectException(InvalidOrderByException::class);
+        $this->expectExceptionMessage(InvalidOrderByException::NO_DIMENSION_ORDER_BY);
+
+        Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->alphanumericDimensionAsc(fn (Dimensions $dimensions) => $dimensions)
+            );
+    }
+
+    public function test_order_by_alphanumeric_dimension_asc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->alphanumericDimensionAsc(fn (Dimensions $dimensions) => $dimensions->browser())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'dimension' => [
+                'dimensionName' => 'browser',
+                'orderType' => 'ALPHANUMERIC',
+            ],
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_order_by_alphanumeric_dimension_desc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->alphanumericDimensionDesc(fn (Dimensions $dimensions) => $dimensions->browser())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'dimension' => [
+                'dimensionName' => 'browser',
+                'orderType' => 'ALPHANUMERIC',
+            ],
+            'desc' => true,
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_order_by_case_insensitive_alphanumeric_dimension_asc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->caseInsensitiveAlphanumericDimensionAsc(fn (Dimensions $dimensions) => $dimensions->browser())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'dimension' => [
+                'dimensionName' => 'browser',
+                'orderType' => 'CASE_INSENSITIVE_ALPHANUMERIC',
+            ],
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_order_by_case_insensitive_alphanumeric_dimension_desc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->caseInsensitiveAlphanumericDimensionDesc(fn (Dimensions $dimensions) => $dimensions->browser())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'dimension' => [
+                'dimensionName' => 'browser',
+                'orderType' => 'CASE_INSENSITIVE_ALPHANUMERIC',
+            ],
+            'desc' => true,
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_order_by_case_insensitive_numeric_dimension_asc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->numericDimensionAsc(fn (Dimensions $dimensions) => $dimensions->browser())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'dimension' => [
+                'dimensionName' => 'browser',
+                'orderType' => 'NUMERIC',
+            ],
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+
+    public function test_order_by_case_numeric_dimension_desc(): void
+    {
+        $analytics = Analytics::query()
+            ->setOrderBys(fn (OrderBy $orderBy) => $orderBy
+                ->numericDimensionDesc(fn (Dimensions $dimensions) => $dimensions->browser())
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $orderBy = $requestData->orderBys->first();
+
+        $this->assertNotNull($orderBy);
+
+        $this->assertInstanceOf(BaseOrderBy::class, $orderBy);
+
+        $this->assertEquals([
+            'dimension' => [
+                'dimensionName' => 'browser',
+                'orderType' => 'NUMERIC',
+            ],
+            'desc' => true,
+        ], json_decode($orderBy->serializeToJsonString(), true));
+    }
+}


### PR DESCRIPTION
Closes #53 

Excerpt from README

### <a name="ordering">Ordering:</a>

You can order the results by a metric or dimension by using the `setOrderBys()` method. This method accepts a callback that receives an `OrderBy` instance. You can then use the `OrderBy` instance to order the results using these methods:

* `metricDesc()` - Order by a metric in descending order.
* `metricAsc()` - Order by a metric in ascending order.
* `alphanumericDimensionDesc()` - Order by a dimension in descending order (case-sensitive).
* `alphanumericDimensionAsc()` - Order by a dimension in ascending order (case-sensitive).
* `caseInsensitiveAlphanumericDimensionDesc()` - Order by a dimension in descending order (case-insensitive).
* `caseInsensitiveAlphanumericDimensionAsc()` - Order by a dimension in ascending order (case-insensitive).
* `numericDimensionDesc()` - Order by a dimension in descending order (numeric).
* `numericDimensionAsc()` - Order by a dimension in ascending order (numeric).

##### Example:
```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser())
    ->forPeriod(Period::defaultPeriod())
    ->setOrderBys(fn(OrderBy $orderBy) => $orderBy
    	// Order by sessions in descending order
        ->metricDesc(
            metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
        )

        // Order by sessions in ascending order
        ->metricAsc(
            metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
        )

        // Order by browser in descending order (case-sensitive)
        ->alphanumericDimensionDesc(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
        )

        // Order by browser in ascending order (case-sensitive)
        ->alphanumericDimensionAsc(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
        )

        // Order by browser in descending order (case-insensitive)
        ->caseInsensitiveAlphanumericDimensionDesc(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
        )

        // Order by browser in ascending order (case-insensitive)
        ->caseInsensitiveAlphanumericDimensionAsc(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
        )

        // Order by browser in descending order (numeric)
        ->numericDimensionDesc(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
        )

        // Order by browser in ascending order (numeric)
        ->numericDimensionAsc(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
        )
    )
    ->run();
```